### PR TITLE
Member.shortDescription and Member.longDescription

### DIFF
--- a/app/views/Dashboard/index.html
+++ b/app/views/Dashboard/index.html
@@ -54,13 +54,13 @@
                 #{if member.links}
                     <h3>Vous êtes lié à :</h3>
                     #{list items:member.links, as:'link'}
-                       #{member link, short:true}
+                       #{member link, short:true /}
                     #{/list}
                 #{/if}
                 #{if member.linkers}
                     <h3>Ils vous ont lié :</h3>
                     #{list items:member.linkers, as:'link'}
-                       #{member link, short:true}
+                       #{member link, short:true /}
                     #{/list}
                 #{/if}
                 #{if suggestedMembers}


### PR DESCRIPTION
Member.shortDescription < 140 char and always displayed (in profile, and in twipsy for member link)
Member.longDescription is facultative and length-free, and optionnaly displayed on profile (with a smooth animation).
ALWAYS use custom tag "member" to display a member (as link, as speaker, as ...).
