### PR TITLE
Bug fix : Article.headline max length validation : 500 -> 255

### DIFF
--- a/app/models/Article.java
+++ b/app/models/Article.java
@@ -60,7 +60,7 @@ public class Article extends Model implements Lookable, Comparable<Article> {
     /** Markdown enabled */
     @Column(name = HEADLINE)
     @Required
-    @MaxSize(500)
+    @MaxSize(255)
     @Field
     public String headline;
 

--- a/app/views/Articles/edit.html
+++ b/app/views/Articles/edit.html
@@ -10,7 +10,7 @@
 <script lang="text/javascript">
     $(function() {
         registerLimited('#article_title', '#article_titleCountdown', 50, "&{'remainingChars'}");
-        registerLimited('#article_headline', '#article_headlineCountdown', 500, "&{'remainingChars'}");
+        registerLimited('#article_headline', '#article_headlineCountdown', 255, "&{'remainingChars'}");
     });
 </script>
 #{/set}
@@ -45,7 +45,7 @@
                 <div class="clearfix ${field.error?'error':''}"> 
                     <label for="${field.name}">&{field.name}</label> 
                     <div class="input"> 
-                        <textarea class="xxlarge" id="${field.id}" name="${field.name}" size="50" maxlength="500" rows="3">${field.value}</textarea>
+                        <textarea class="xxlarge" id="${field.id}" name="${field.name}" size="50" maxlength="255" rows="3">${field.value}</textarea>
                         <span class="help-block" id="${field.id}Countdown" style="font-weight: bold">countdown</span>
                         <span class="help-block">${field.error}</span>
                         <span class="help-block">&{field.name+".note"}</span>


### PR DESCRIPTION
...ing mapped by Hibernate are persisted as VARCHAR(255) by default. https://trello.com/card/saisie-d-article-headline-limit-e-255-et-non-pas-500-comme-indiqu-e/4e723ede171d7c0000032cae/267
