### PR TITLE
Catch exception on batch item and skip it to execute next items

### DIFF
--- a/app/controllers/JobFetchAllUsersTimelines.java
+++ b/app/controllers/JobFetchAllUsersTimelines.java
@@ -38,11 +38,15 @@ public class JobFetchAllUsersTimelines extends Job {
             txTemplate.setReadOnly(false);
             for (final Long id : accountsId) {
 
-                txTemplate.execute(new TransactionCallbackWithoutResult() {
-                    public void doInTransaction() {
-                        StatusActivity.fetchForAccount(id);
-                    }
-                });
+                try {
+                    txTemplate.execute(new TransactionCallbackWithoutResult() {
+                        public void doInTransaction() {
+                            StatusActivity.fetchForAccount(id);
+                        }
+                    });
+                } catch (Exception e) {
+                    Logger.error("Exception while fetching account, skipped to next", e);
+                }
             }
             Logger.info("END fetch timelines");
         }

--- a/app/controllers/JobFetchRegisteredTicketingForAllUsers.java
+++ b/app/controllers/JobFetchRegisteredTicketingForAllUsers.java
@@ -42,13 +42,17 @@ public class JobFetchRegisteredTicketingForAllUsers extends Job {
         txTemplate.setReadOnly(false);
         for (final Long memberId : memberIds) {
 
-            txTemplate.execute(new TransactionCallbackWithoutResult() {
-                public void doInTransaction() {
-                    final Member member = Member.findById(memberId);
-                    member.setTicketingRegistered(WeezEvent.isRegisteredAttendee(member.email, attendees));
-                    member.save();
-                }
-            });
+            try {
+                txTemplate.execute(new TransactionCallbackWithoutResult() {
+                    public void doInTransaction() {
+                        final Member member = Member.findById(memberId);
+                        member.setTicketingRegistered(WeezEvent.isRegisteredAttendee(member.email, attendees));
+                        member.save();
+                    }
+                });
+            } catch (Exception e) {
+                Logger.error("Exception while registering user, skipped to next", e);
+            }
         }
 
         Logger.info("END JOB JobFetchRegisteredTicketingUser for all members");


### PR DESCRIPTION
Supposed to prevent timeline fetching batch to crash at first encountered exception.
